### PR TITLE
Validation rules serialization changes

### DIFF
--- a/src/retold/as_jsonld.clj
+++ b/src/retold/as_jsonld.clj
@@ -73,7 +73,9 @@
 (defn sms-rules [derived entity]
   (let [[_ props] entity
         rules (get-in props [:annotations :validationRules])]
-    (assoc derived "sms:validationRules" (conj [] rules))))
+    (if rules
+      (assoc derived "sms:validationRules" (conj '() rules))
+      (assoc derived "sms:validationRules" '()))))
 
 (defn base-entity [entity]
   (let [[k props] entity]

--- a/src/retold/as_jsonld.clj
+++ b/src/retold/as_jsonld.clj
@@ -71,9 +71,9 @@
     (if deps (assoc derived "sms:requiresDependency" (id-refs (str/split deps #","))) derived)))
 
 (defn sms-rules [derived entity]
-  (let [[_ props] entity]
-    (if-let [rules (get-in props [:annotations :validationRules])]
-      (assoc derived "sms:validationRules" (list rules)) derived)))
+  (let [[_ props] entity
+        rules (get-in props [:annotations :validationRules])]
+    (assoc derived "sms:validationRules" (conj [] rules))))
 
 (defn base-entity [entity]
   (let [[k props] entity]


### PR DESCRIPTION
Currently, when validation rules are not present, it is not present in the final JSON-LD export.

However, recent changes means we always want the property, and as empty array when no rules are specified.